### PR TITLE
Added autoHead functionality to get interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,32 @@ final interceptor = nock.get("/video")
   ..reply(200, <int>[73, 32, 97, 109, 32, 118, 105, 100, 101, 111]);
 ```
 
+### Specifying `head` method responses
+
+Under normal circumstances, a `get` interceptor will imply a corresponding `head` response:
+
+For example:
+```dart
+final interceptor = nock.get("/ping")
+  ..reply(200, "pong");
+```
+responds to both `get` and `head`.  
+
+You can suppress the standard head response as follows:
+```dart
+final interceptor = nock.get("/ping")
+  ..reply(200, "pong", autoHead: false);
+```
+which responds normally to `get` requests, but responds to `head` requests by throwing `NetConnectionNotAllowed`.
+
+You can also override the standard head response just by declaring it:
+```dart
+final getInterceptor = nock.get("/ping")
+  ..reply(200, "pong");
+final headInterceptor = nock.head("/ping")
+  ..reply(400, "invalid head request");
+```
+
 ### Specifying reply headers
 
 Other binary data:

--- a/lib/nock.dart
+++ b/lib/nock.dart
@@ -52,7 +52,7 @@ class _Nock implements Nock {
   }
 
   @override
-  Interceptor get(path) => _defaultScope.get(path);
+  Interceptor get(path, {bool autoHead = true}) => _defaultScope.get(path, autoHead: autoHead);
 
   @override
   Interceptor post(path, [data]) => _defaultScope.post(path, data);

--- a/lib/src/interceptor.dart
+++ b/lib/src/interceptor.dart
@@ -13,8 +13,12 @@ final registry = Registry();
 
 class Registry {
   final _interceptors = <Interceptor>[];
+  final _automaticInterceptors = <Interceptor>[];
 
-  void cleanAll() => _interceptors.clear();
+  void cleanAll() {
+    _interceptors.clear();
+    _automaticInterceptors.clear();
+  }
 
   Iterable<Interceptor> get pendingMocks => _interceptors.where(
         (interceptor) => !interceptor.isDone,
@@ -22,7 +26,17 @@ class Registry {
 
   Iterable<Interceptor> get activeMocks => _interceptors;
 
-  void add(Interceptor interceptor) => _interceptors.add(interceptor);
+  void add(Interceptor interceptor) {
+    _interceptors.add(interceptor);
+
+    if (interceptor.generateAuto){
+      if (interceptor._matcher.method.toUpperCase() == 'GET') {
+        _automaticInterceptors.add(interceptor.copyWith(
+            matcher: interceptor._matcher.copyWith(method: 'HEAD'), body: '' // empty string, because the receiver can't tell the difference between a null parameter and a non-exstent parameter
+            ));
+      }
+    }
+  }
 
   void remove(Interceptor interceptor) {
     _interceptors.remove(interceptor);
@@ -31,6 +45,12 @@ class Registry {
 
   Interceptor? match(HttpClientRequest request) {
     for (var interceptor in _interceptors) {
+      if (interceptor._matcher.match(request as MockHttpClientRequest)) {
+        return interceptor;
+      }
+    }
+
+    for (var interceptor in _automaticInterceptors) {
       if (interceptor._matcher.match(request as MockHttpClientRequest)) {
         return interceptor;
       }
@@ -53,11 +73,12 @@ class Registry {
 
 typedef ExceptionThrower = void Function();
 
-class Interceptor {
+class  Interceptor {
   final RequestMatcher _matcher;
+  final bool generateAuto;
 
   Map<String, String>? replyHeaders;
-  late int statusCode;
+  int? statusCode;
   dynamic body;
   Function? exception;
 
@@ -68,7 +89,18 @@ class Interceptor {
 
   StreamController? _onReply;
 
-  Interceptor(this._matcher);
+  Interceptor(this._matcher, {this.generateAuto = true});
+  Interceptor copyWith({RequestMatcher? matcher, dynamic body, int? statusCode}) {
+    var rv =  Interceptor(matcher ?? _matcher);
+    rv._isPersist = _isPersist;
+    rv._isDone = _isDone;
+    rv._isRegistered = _isRegistered;
+    rv._isCanceled = _isCanceled;
+    final newStatusCode = statusCode ?? this.statusCode;
+    if (newStatusCode != null) rv.reply (newStatusCode, (body == '') ? null : body ?? this.body, headers:replyHeaders);
+    return rv;
+  }
+
 
   bool get isDone => _isDone;
 
@@ -82,7 +114,8 @@ class Interceptor {
     }
 
     if (_isRegistered) {
-      throw AlreadyRegistered(this);
+      return;
+      // throw AlreadyRegistered(this); // not an error to attempt to re-register - it might happen when copying. But definitely don't register twice.
     }
 
     _isRegistered = true;
@@ -197,4 +230,5 @@ class Interceptor {
       callback();
     });
   }
+
 }

--- a/lib/src/overrides.dart
+++ b/lib/src/overrides.dart
@@ -181,12 +181,16 @@ class MockHttpClientRequest extends HttpClientRequest {
       throw interceptor.exception!();
     }
 
+    if (interceptor.statusCode == null) { // Implies we haven't defined a reply yet.
+      throw NetConnectionNotAllowed(this, registry.pendingMocks);
+    }
+
     final headers = MockHttpHeaders('1.1');
     interceptor.replyHeaders?.forEach((key, value) => headers.add(key, value));
 
     return MockHttpClientResponse(
       headers,
-      interceptor.statusCode,
+      interceptor.statusCode!,
       interceptor.content,
     );
   }

--- a/lib/src/request_matcher.dart
+++ b/lib/src/request_matcher.dart
@@ -13,6 +13,10 @@ class RequestMatcher {
 
   RequestMatcher(this.method, this.uri, this.body);
 
+  RequestMatcher copyWith({String? method, UriMatcher? uri, BodyMatcher? body}) {
+    return RequestMatcher (method ?? this.method, uri ?? this.uri, body ?? this.body);
+  }
+
   bool match(MockHttpClientRequest request) {
     return method.toUpperCase() == request.method.toUpperCase() &&
         uri.match(request.uri)! &&

--- a/lib/src/scope.dart
+++ b/lib/src/scope.dart
@@ -5,15 +5,16 @@ class NockScope {
 
   NockScope(this._baseUrl);
 
-  Interceptor _when(String method, dynamic path, dynamic data) => Interceptor(
+  Interceptor _when(String method, dynamic path, dynamic data, {bool generateAuto = true}) => Interceptor(
         RequestMatcher(
           method,
           UriMatcher(_baseUrl, path),
           BodyMatcher(data),
         ),
+      generateAuto: generateAuto,
       );
 
-  Interceptor get(path) => _when('get', path, null);
+  Interceptor get(path, {bool autoHead = true}) => _when('get', path, null, generateAuto: autoHead);
 
   Interceptor post(path, [data]) => _when('post', path, data);
 


### PR DESCRIPTION
Added autoHead functionality to `get` requests.

Now, if there's a `get` interceptor, there will automatically be an equivalent `head` interceptor.  You can control the behaviour by:
- adding autoHead:false to the `get` interceptor;
- adding a replacement `head` interceptor

Explanation and examples in the readme.