### PR TITLE
Update http_headers to match SDK 3.0.0

### DIFF
--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -8,17 +8,17 @@ class NetConnectionNotAllowed extends Error {
 
   @override
   String toString() {
-    return "Request was: $_request\n$_pending";
+    return 'Request was: $_request\n$_pending';
   }
 
-  String get _request => "${request.method} ${request.uri}";
+  String get _request => '${request.method} ${request.uri}';
 
   String get _pending {
     if (pendingMocks.isEmpty) {
-      return "No pending mocks";
+      return 'No pending mocks';
     }
 
-    return "Pending mocks: " + pendingMocks.toString();
+    return 'Pending mocks: ' + pendingMocks.toString();
   }
 }
 
@@ -28,7 +28,7 @@ class UnknownUrlMatcherType implements Exception {
   UnknownUrlMatcherType(this.url);
 
   @override
-  String toString() => "Unknown url matcher type ${url.runtimeType}";
+  String toString() => 'Unknown url matcher type ${url.runtimeType}';
 }
 
 class AlreadyRegistered implements Exception {
@@ -37,7 +37,7 @@ class AlreadyRegistered implements Exception {
   AlreadyRegistered(this.interceptor);
 
   @override
-  String toString() => "Request ${interceptor} already registered";
+  String toString() => 'Request $interceptor already registered';
 }
 
 class AlreadyCanceled implements Exception {
@@ -46,7 +46,7 @@ class AlreadyCanceled implements Exception {
   AlreadyCanceled(this.interceptor);
 
   @override
-  String toString() => "Request ${interceptor} was canceled";
+  String toString() => 'Request $interceptor was canceled';
 }
 
 class MockIsNotActive implements Exception {
@@ -55,7 +55,7 @@ class MockIsNotActive implements Exception {
   MockIsNotActive(this.interceptor);
 
   @override
-  String toString() => "Request ${interceptor} is not active";
+  String toString() => 'Request $interceptor is not active';
 }
 
 class UnknownBodyType implements Exception {
@@ -64,7 +64,7 @@ class UnknownBodyType implements Exception {
   UnknownBodyType(this.body);
 
   @override
-  String toString() => "Unknown body type ${body.runtimeType}";
+  String toString() => 'Unknown body type ${body.runtimeType}';
 }
 
 class UnknownQueryMatcherType implements Exception {
@@ -73,5 +73,5 @@ class UnknownQueryMatcherType implements Exception {
   UnknownQueryMatcherType(this.query);
 
   @override
-  String toString() => "Unknown query matcher type ${query.runtimeType}";
+  String toString() => 'Unknown query matcher type ${query.runtimeType}';
 }

--- a/test/nock_test.dart
+++ b/test/nock_test.dart
@@ -130,7 +130,7 @@ void main() {
     expect(isCompleted, true);
   });
 
-  test("persist", () async {
+  test('persist', () async {
     final result = {'foo': 'bar'};
 
     final scope = nock('http://127.0.0.1').get('/subpath')
@@ -288,7 +288,7 @@ void main() {
       final response = await req.close();
       final body = await response.transform(utf8.decoder).toList();
 
-      expect(body.join(), "baz");
+      expect(body.join(), 'baz');
     }
   });
 
@@ -309,7 +309,7 @@ void main() {
   });
 
   test('exception', () async {
-    nock('http://127.0.0.1').get("/subpath").throwing(() => 'my exception');
+    nock('http://127.0.0.1').get('/subpath').throwing(() => 'my exception');
 
     final uri = Uri.parse('http://127.0.0.1/subpath');
     final req = await client.getUrl(uri);

--- a/test/uri_matcher_test.dart
+++ b/test/uri_matcher_test.dart
@@ -2,155 +2,155 @@ import 'package:nock/src/interceptor.dart';
 import 'package:test/test.dart';
 
 void main() {
-  final base = "http://127.0.0.1";
+  final base = 'http://127.0.0.1';
 
-  group("general", () {
-    test("base", () {
+  group('general', () {
+    test('base', () {
       expect(
-        UriMatcher(base, "/url").match(Uri.parse("http://127.0.0.2/url")),
+        UriMatcher(base, '/url').match(Uri.parse('http://127.0.0.2/url')),
         false,
       );
 
       expect(
-        UriMatcher(base, "/url").match(Uri.parse("http://127.0.0.1/url")),
+        UriMatcher(base, '/url').match(Uri.parse('http://127.0.0.1/url')),
         true,
       );
     });
   });
 
-  group("cases", () {
+  group('cases', () {
     final cases = [
       // String
       _Case(
-        expected: "/url",
-        actual: "/url",
+        expected: '/url',
+        actual: '/url',
         result: true,
       ),
       _Case(
-        expected: "/url",
-        actual: "/other",
+        expected: '/url',
+        actual: '/other',
         result: false,
       ),
       _Case(
-        expected: "/url?",
-        actual: "/url",
+        expected: '/url?',
+        actual: '/url',
         result: true,
       ),
       // query
       _Case(
-        expected: "/url?a=3",
-        actual: "/url",
+        expected: '/url?a=3',
+        actual: '/url',
         result: false,
       ),
       _Case(
-        expected: "/url?a=10",
-        actual: "/url",
-        query: "b=123",
+        expected: '/url?a=10',
+        actual: '/url',
+        query: 'b=123',
         result: false,
       ),
       _Case(
-        expected: "/url?a=3&b=5",
-        actual: "/url?b=5&a=3",
+        expected: '/url?a=3&b=5',
+        actual: '/url?b=5&a=3',
         result: true,
       ),
       _Case(
-        expected: "/url",
-        actual: "/url?a[]=3&a[]=5",
+        expected: '/url',
+        actual: '/url?a[]=3&a[]=5',
         query: {
-          'a[]': ["3", "5"]
+          'a[]': ['3', '5']
         },
         result: true,
       ),
       // Regexp
       _Case(
-        expected: RegExp(r"url$"),
-        actual: "/some/url",
+        expected: RegExp(r'url$'),
+        actual: '/some/url',
         result: true,
       ),
       _Case(
-        expected: RegExp(r"url$"),
-        actual: "/some/url/other",
+        expected: RegExp(r'url$'),
+        actual: '/some/url/other',
         result: false,
       ),
       _Case(
-        expected: RegExp(r"url$"),
-        actual: "/some/url?something",
-        query: "other",
+        expected: RegExp(r'url$'),
+        actual: '/some/url?something',
+        query: 'other',
         result: false,
       ),
       _Case(
-        expected: RegExp(r"url$"),
-        actual: "/some/url?something",
-        query: "something",
+        expected: RegExp(r'url$'),
+        actual: '/some/url?something',
+        query: 'something',
         result: true,
       ),
       // Function
       _Case(
         expected: (Uri uri) => true,
-        actual: "/some/url?something",
+        actual: '/some/url?something',
         result: true,
       ),
       _Case(
         expected: (Uri uri) => false,
-        actual: "/some/url?something",
+        actual: '/some/url?something',
         result: false,
       ),
       // Matcher
       _Case(
-        expected: startsWith("/some"),
-        actual: "/some/url",
+        expected: startsWith('/some'),
+        actual: '/some/url',
         result: true,
       ),
       _Case(
-        expected: "/some/url",
-        actual: "/some/url?a=5",
-        query: {"a": anyOf("5", "6")},
+        expected: '/some/url',
+        actual: '/some/url?a=5',
+        query: {'a': anyOf('5', '6')},
         result: true,
       ),
       // Query function
       _Case(
-        expected: "/some/url",
+        expected: '/some/url',
         query: (Map<String, String> data) => false,
-        actual: "/some/url",
+        actual: '/some/url',
         result: false,
       ),
       _Case(
-        expected: "/some/url",
+        expected: '/some/url',
         query: (Map<String, String> data) => true,
-        actual: "/some/url",
+        actual: '/some/url',
         result: true,
       ),
       _Case(
-        expected: "/some/url",
+        expected: '/some/url',
         query: (Map<String, List<String>> data) => false,
-        actual: "/some/url",
+        actual: '/some/url',
         result: false,
       ),
       _Case(
-        expected: "/some/url",
+        expected: '/some/url',
         query: (Map<String, List<String>> data) => true,
-        actual: "/some/url",
+        actual: '/some/url',
         result: true,
       ),
       _Case(
-        expected: startsWith("/some/url?value="),
-        actual: "/some/url?value=12312312",
+        expected: startsWith('/some/url?value='),
+        actual: '/some/url?value=12312312',
         result: true,
       ),
     ];
 
     cases.forEach((c) {
-      String description = c.expected.toString();
+      var description = c.expected.toString();
 
       if (c.query != null) {
         if (c.query is String) {
           description += ' "${c.query}"';
         } else {
-          description += " ${c.query}";
+          description += ' ${c.query}';
         }
       }
 
-      description += " -> ${c.actual}";
+      description += ' -> ${c.actual}';
 
       test(description, () {
         final matcher = UriMatcher(base, c.expected);


### PR DESCRIPTION
Nock currently fails on SDK versions 3.0.0 and above due to [breaking change #51486](https://github.com/dart-lang/sdk/issues/51486). This PR copies the new implementation of `http_headers.dart` from the SDK to ensure it is up to date.

Also ran `dart fix --apply` to resolve a lot of lints introduced by `package:pedantic`.