### PR TITLE
Bump SameSite minimum SDK & apply new class modifiers on `HttpClientRequest`

### DIFF
--- a/lib/src/overrides.dart
+++ b/lib/src/overrides.dart
@@ -147,7 +147,7 @@ class MockClient implements HttpClient {
   Function(String line)? keyLog;
 }
 
-class MockHttpClientRequest extends HttpClientRequest {
+class MockHttpClientRequest implements HttpClientRequest {
   @override
   final String method;
 
@@ -159,6 +159,21 @@ class MockHttpClientRequest extends HttpClientRequest {
 
   @override
   late Encoding encoding;
+
+  @override
+  bool bufferOutput = true;
+
+  @override
+  int contentLength = -1;
+
+  @override
+  bool followRedirects = true;
+
+  @override
+  int maxRedirects = 5;
+
+  @override
+  bool persistentConnection = true;
 
   final body = <int>[];
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.2.1
 homepage: https://github.com/cah4a/dart_nock
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=3.1.0 <4.0.0'
 
 dependencies:
   test: ^1.16.5


### PR DESCRIPTION
As discussed in #21, `SameSite` does not yet exist in 3.0 - it will be released in 3.1. I use the dev version of the SDK so I hadn't noticed the difference, but now the pubspec has been updated accordingly.

This **will not work** until Dart 3.1 is released stable due to how semver handles beta versions. (3.1.0-beta is before 3.1.0, so it doesn't satisfy >3.1.0).

This PR also applies changes needed to `MockHttpClientRequest` due to `HttpClientRequest` having the `interface` class modifier, which disables extension and only allows implementation.