### PR TITLE
Fixed issue #23

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,5 +11,5 @@ dependencies:
   collection: ^1.15.0
 
 dev_dependencies:
-  http: ^0.13.0
+  http: ^1.1.0
   pedantic: ^1.11.0


### PR DESCRIPTION
Updated [http](https://pub.dev/packages/http) library for latest flutter version and fixed Error: The non-abstract class '_Cookie' is missing implementations for these members: Cookie.sameSite. [#23](https://github.com/cah4a/dart_nock/issues/23)