### PR TITLE
move test to dev dependencies 

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,9 +7,9 @@ environment:
   sdk: '>=3.1.0 <4.0.0'
 
 dependencies:
-  test: ^1.16.5
   collection: ^1.15.0
 
 dev_dependencies:
+  test: ^1.16.5
   http: ^1.1.0
   pedantic: ^1.11.0


### PR DESCRIPTION
I got conflicts with other packages (analyzer < 6.0). But the `test` dependency doesn't even have to be in the main dependencies. Just in dev will do :-)

All tests still green and no errors.